### PR TITLE
Feature [a009] Add Update User MQTT Password Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,55 @@ docker build -t simple-iot-api-gateway:{tag} .
 
 </details>
 
+#### Update User MQTT Password
+
+<details>
+ <summary><code>PATCH</code> <code><b>/users/mqtt/password</b></code> <code>(Update user mqtt password)</code></summary>
+
+##### Note
+
+By default if mqtt password is not set, base password will be used for mqtt authentication instead.
+
+##### Authentication
+
+> | cookie key | type | description |      
+> |--------|------|-------------|
+> | `accessToken` | string | a JWT Token Set from `/auth/login` or `/auth/refresh` |
+
+##### Parameters
+
+> None
+
+##### Body
+
+> | name | type | data type | description |
+> |------|------|-----------|-------------|
+> | password | required | string | string of mqtt password  |
+
+
+##### Responses
+
+> | http code | content-type | response |
+> |-----------|--------------|----------|
+> | `201` | `application/json` | `{"id": 1 ,"username": hello}` |
+> | `400` | `application/json` | `{"message": "Validation failed","statusCode": 400}` |
+> | `404` | `application/json` | `{"message": "User is not exist", "statusCode": 404}` |
+
+##### Example cURL
+
+> ```javascript
+> curl --request PATCH
+> --location 'http://localhost:3000/users/mqtt/password' \
+> --header 'Cookie: accessToken={{JWT_TOKEN}}' \
+> --header 'Content-Type: application/json' \
+> --data '{
+>    "password": "world"
+> }'
+> ```
+
+</details>
+
+
 #### Get User Detail
 
 <details>
@@ -180,7 +229,7 @@ docker build -t simple-iot-api-gateway:{tag} .
 ##### Example cURL
 
 > ```javascript
-> curl --location --request DELETE 'http://localhost:3000/users/1' \
+> curl --location --request GET 'http://localhost:3000/users/1' \
 > --header 'Cookie: accessToken={{JWT_TOKEN}}' \
 > --header 'Content-Type: application/json'
 > ```

--- a/src/users/mocks/users.service.mock.ts
+++ b/src/users/mocks/users.service.mock.ts
@@ -4,6 +4,9 @@ export class UsersServiceMock {
       register: jest.fn().mockResolvedValue('register Received'),
       unregister: jest.fn().mockResolvedValue('unregister Received'),
       getUserDetails: jest.fn().mockResolvedValue('getUserDetails Received'),
+      updateMqttPassword: jest
+        .fn()
+        .mockResolvedValue('updateMqttPassword Received'),
     };
   }
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -78,4 +78,22 @@ describe('UsersController', () => {
       expect(service.getUserDetails).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('[PATCH] /users/mqtt/password', () => {
+    it('should send data to service.updateMqttPassword', async () => {
+      // Act & Assert
+      expect(
+        await controller.updateMqttPassword(
+          {
+            user: {
+              username: 'user1',
+              sub: 1,
+            },
+          },
+          'pass',
+        ),
+      ).toEqual('updateMqttPassword Received');
+      expect(service.updateMqttPassword).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   ParseIntPipe,
   UnauthorizedException,
+  Patch,
 } from '@nestjs/common';
 import { Public } from '../auth/auth.public';
 import { UsersService } from './users.service';
@@ -47,5 +48,10 @@ export class UsersController {
     return req.user.sub === userId
       ? this.usersService.getUserDetails(req.user.sub)
       : new UnauthorizedException();
+  }
+
+  @Patch('mqtt/password')
+  updateMqttPassword(@Request() req, @Body('password') password: string) {
+    return this.usersService.updateMqttPassword(req.user.sub, password);
   }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -99,4 +99,31 @@ describe('UsersService', () => {
       await expect(service.getUserDetails(userId)).rejects.toThrow(error);
     });
   });
+
+  describe('updateMqttPassword', () => {
+    it('should send update mqtt password command to user service', async () => {
+      // Arrange
+      const userId = 1;
+      const password = 'password';
+
+      // Act & Assert
+      expect(await service.updateMqttPassword(userId, password)).toEqual({
+        pattern: { cmd: 'users.mqtt.update.password' },
+        payload: { userId, password },
+      });
+    });
+
+    it('should throw an error if user service throws an error', async () => {
+      // Arrange
+      const userId = 1;
+      const password = 'password';
+      const error = new RpcException('User service error');
+      userClientMock.error = error;
+
+      // Act & Assert
+      await expect(
+        service.updateMqttPassword(userId, password),
+      ).rejects.toThrow(error);
+    });
+  });
 });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -34,4 +34,14 @@ export class UsersService {
         .pipe(catchError((err) => throwError(() => new RpcException(err)))),
     );
   }
+
+  async updateMqttPassword(userId: number, password: string): Promise<any> {
+    const pattern = { cmd: 'users.mqtt.update.password' };
+    const payload = { userId, password };
+    return firstValueFrom(
+      this.client
+        .send(pattern, payload)
+        .pipe(catchError((err) => throwError(() => new RpcException(err)))),
+    );
+  }
 }


### PR DESCRIPTION
- Add a `PATCH` endpoint of `/users/mqtt/password` for updating the user MQTT password.
- Update API docs in `README.md`